### PR TITLE
send content-disposition HTTP header for PDFs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 # Puppeteer(Chrome headless node API) based web page renderer
 
-Puppeteer(Chrome headless node API) based web page renderer.
+[Puppeteer](https://github.com/GoogleChrome/puppeteer) (Chrome headless node API) based web page renderer.
 
-Useful server side rendering through proxy.
-
+Useful server side rendering through proxy. Outputs HTML, PDF and screenshots as PNG.
 
 ## Requirements
 You can run Chromium or docker.
-
 
 ## Getting Started
 
@@ -40,7 +38,7 @@ const renderer = require('puppeteer-renderer-middleware');
 const app = express();
 
 app.use(renderer({
-  url: 'http://installed-your-puppeterr-renderer-url',
+  url: 'http://installed-your-puppeteer-renderer-url',
   // userAgentPattern: /My-Custom-Agent/i,
   // excludeUrlPattern: /*.html$/i
   // timeout: 30 * 1000,
@@ -53,9 +51,25 @@ app.listen(8080);
 
 ## API
 
-| Name  | Required | Value           | Description            |Usage                                                   |
-|-------|:--------:|:---------------:|------------------------|--------------------------------------------------------|
-|url    |O         |                 |Target URL              |http://puppeterr-renderer?url=http://www.google.com         |
-|type   |          |(pdf\|screenshot)|Rendering another type. |http://puppeterr-renderer?url=http://www.google.com&type=pdf|
-|(Extra options)|  |                 |Extra options. (see puppeteer API doc)          |http://puppeterr-renderer?url=http://www.google.com&type=pdf&scale=2|
+| Name    | Required | Value               | Description            |Usage                                                         |
+|---------|:--------:|:-------------------:|------------------------|--------------------------------------------------------------|
+|`url`    | yes      |                     |Target URL              |`http://puppeteer-renderer?url=http://www.google.com`         |
+|`type`   |          |`pdf` or `screenshot`|Rendering another type. |`http://puppeteer-renderer?url=http://www.google.com&type=pdf`|
+|(Extra options)|    |                     |Extra options (see [puppeteer API doc](https://github.com/GoogleChrome/puppeteer/blob/v1.1.0/docs/api.md#pagepdfoptions)) |`http://puppeteer-renderer?url=http://www.google.com&type=pdf&scale=2`|
+
+## PDF File Name Convention
+
+Generated PDFs are returned with a `Content-disposition` header requesting the browser to download the file instead of showing it.
+The file name is generated from the URL rendered:
+
+| URL                                           | Filename                     |   
+|-----------------------------------------------|------------------------------|   
+| `https://www.example.com/`                    | `www.example.com.pdf`        |
+| `https://www.example.com:80/`                 | `www.example.com.pdf`        |
+| `https://www.example.com/resource`            | `resource.pdf`               |
+| `https://www.example.com/resource.extension`  | `resource.pdf`               |
+| `https://www.example.com/path/`               | `path.pdf`                   |
+| `https://www.example.com/path/to/`            | `pathto.pdf`                 |
+| `https://www.example.com/path/to/resource`    | `resource.pdf`               |
+| `https://www.example.com/path/to/resource.ext`| `resource.pdf`               |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer-renderer",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "agent-base": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
-      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "requires": {
         "es6-promisify": "5.0.0"
       }
@@ -73,6 +73,11 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -256,7 +261,7 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
     },
@@ -310,9 +315,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -368,16 +373,16 @@
       }
     },
     "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
-        "es6-promise": "4.1.1"
+        "es6-promise": "4.2.4"
       }
     },
     "escape-html": {
@@ -575,29 +580,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "requires": {
         "concat-stream": "1.6.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-        }
       }
     },
     "fd-slicer": {
@@ -701,12 +691,22 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
+      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
       "requires": {
-        "agent-base": "4.1.1",
-        "debug": "2.6.8"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "husky": {
@@ -1140,9 +1140,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.29.0",
@@ -1444,9 +1444,9 @@
       }
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -1465,18 +1465,18 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz",
-      "integrity": "sha512-e00NMdUL32YhBcua9OkVXHgyDEMBWJhDXkYNv0pyKRU1Z1OrsRm5zCpppAdxAsBI+/MJBspFNfOUZuZ24qPGMQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.1.0.tgz",
+      "integrity": "sha512-Up+EiDVtc+EueFUzEFi4JqTlkXdC4pjMng0W9s/uqg2HP7+EHJiIe8OtwP7I+Jk7rI1kS5WIVpqx46aihnLuJQ==",
       "requires": {
-        "debug": "2.6.8",
-        "extract-zip": "1.6.5",
-        "https-proxy-agent": "2.1.0",
-        "mime": "1.3.6",
+        "debug": "2.6.9",
+        "extract-zip": "1.6.6",
+        "https-proxy-agent": "2.1.1",
+        "mime": "1.6.0",
         "progress": "2.0.0",
         "proxy-from-env": "1.0.0",
-        "rimraf": "2.6.1",
-        "ws": "3.1.0"
+        "rimraf": "2.6.2",
+        "ws": "3.3.3"
       }
     },
     "range-parser": {
@@ -1496,14 +1496,14 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -1535,9 +1535,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -1708,9 +1708,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -1737,12 +1737,13 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.1.0.tgz",
-      "integrity": "sha512-TU4/qKFlyQFqNITNWiqPCUY9GqlAhEotlzfcZcve6VT1YEngQl1dDMqwQQS3eMYruJ5r/UD3lcsWib6iVMDGDw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
+        "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
-        "ultron": "1.1.0"
+        "ultron": "1.1.1"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "content-disposition": "^0.5.2",
     "express": "^4.16.2",
     "puppeteer": "^1.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const express = require('express')
+const { URL } = require('url')
+const contentDisposition = require('content-disposition')
 const createRenderer = require('./renderer')
 
 const port = process.env.PORT || 3000
@@ -27,11 +29,20 @@ app.use(async (req, res, next) => {
   try {
     switch (type) {
       case 'pdf':
+        const urlObj = new URL(url)
+        let filename = urlObj.hostname
+        if (urlObj.pathname !== '/') {
+          filename = urlObj.pathname.split('/').pop()
+          if (filename === '') filename = urlObj.pathname.replace(/\//g, '')
+          const extDotPosition = filename.lastIndexOf('.')
+          if (extDotPosition > 0) filename = filename.substring(0, extDotPosition)
+        }
         const pdf = await renderer.pdf(url, options)
         res
           .set({
             'Content-Type': 'application/pdf',
             'Content-Length': pdf.length,
+            'Content-Disposition': contentDisposition(filename + '.pdf'),
           })
           .send(pdf)
         break

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,7 +185,7 @@ concat-stream@1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-content-disposition@0.5.2:
+content-disposition@0.5.2, content-disposition@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
@@ -901,8 +901,8 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 puppeteer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.0.0.tgz#20f3bb6ad6c6778b4d1fb750e808a29fec0a88a4"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.1.0.tgz#97fbc2fbbf9ab659e7e202a68ac1ba54b8bc0a25"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"


### PR DESCRIPTION

 * makes Firefox PDF downloads robust across machines and platforms
 * predefines sane local download filenames with .pdf extension
 * includes cosmetic improvements to the README

Side Effects:
 * Chrome will download PDFs now instead of directly previewing
 * adding a npm dependency also pulled puppeteer up to the new version 1.1.0 in the lockfiles. 
