### PR TITLE
media=print for pdf creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
-FROM zenato/puppeteer
+FROM alpine:edge
 
-USER root
+# Installs latest Chromium (77) package.
+RUN apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      npm
+
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 COPY . /app
-
-RUN cd /app && npm install --quiet
-
+RUN cd /app && npm install --quiet && rm -rf /var/cache/apk/* /root/.node-gyp /usr/share/man /tmp/* \
 EXPOSE 3000
-
 WORKDIR /app
-
 CMD npm run start

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "content-disposition": "^0.5.2",
     "express": "^4.16.3",
-    "puppeteer": "^1.20.0",
+    "puppeteer": "1.19.0",
     "qs": "^6.9.0"
   },
   "devDependencies": {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -8,8 +8,11 @@ class Renderer {
   }
 
   async createPage(url, options = {}) {
-    const { timeout, waitUntil, credentials } = options
+    const { timeout, waitUntil, credentials, emulateMedia } = options
     const page = await this.browser.newPage()
+    if (emulateMedia) {
+      await page.emulateMedia(emulateMedia);
+    }
 
     if (credentials) {
       await page.authenticate(credentials)
@@ -40,7 +43,7 @@ class Renderer {
     let page = null
     try {
       const { timeout, waitUntil, credentials, ...extraOptions } = options
-      page = await this.createPage(url, { timeout, waitUntil, credentials })
+      page = await this.createPage(url, { timeout, waitUntil, credentials, emulateMedia: 'print' })
 
       const { scale = 1.0, displayHeaderFooter, printBackground, landscape } = extraOptions
       const buffer = await page.pdf({
@@ -95,7 +98,7 @@ class Renderer {
 
 async function create(options = {}) {
   const browser = await puppeteer.launch(
-    Object.assign({args: ['--no-sandbox']}, options)
+    Object.assign({args: ['--no-sandbox']}, options, {executablePath: '/usr/bin/chromium-browser'})
   )
   return new Renderer(browser)
 }


### PR DESCRIPTION
page.emulateMedia('print') for PDF creation to make sure all assets that are only visible in print-css are loaded
See https://github.com/puppeteer/puppeteer/issues/436#issuecomment-564008025 for details