### PR TITLE
media=print for pdf creation

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -8,8 +8,11 @@ class Renderer {
   }
 
   async createPage(url, options = {}) {
-    const { timeout, waitUntil, credentials } = options
+    const { timeout, waitUntil, credentials, emulateMedia } = options
     const page = await this.browser.newPage()
+    if (emulateMedia) {
+      await page.emulateMedia(emulateMedia);
+    }
 
     if (credentials) {
       await page.authenticate(credentials)
@@ -40,7 +43,7 @@ class Renderer {
     let page = null
     try {
       const { timeout, waitUntil, credentials, ...extraOptions } = options
-      page = await this.createPage(url, { timeout, waitUntil, credentials })
+      page = await this.createPage(url, { timeout, waitUntil, credentials, emulateMedia: 'print' })
 
       const { scale = 1.0, displayHeaderFooter, printBackground, landscape } = extraOptions
       const buffer = await page.pdf({


### PR DESCRIPTION
page.emulateMedia('print') for PDF creation to make sure all assets that are only visible in print-css are loaded
See puppeteer/puppeteer#436 (comment) for details