### PR TITLE
Fix 'memory leak' caused by unclosed pages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ app.use(async (req, res, next) => {
         );
         res
           .set({
-            "Content-Type": `image/${screenshotType}`,
+            "Content-Type": `image/${(screenshotType || 'png')}`,
             "Content-Length": buffer.length,
           })
           .send(buffer);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -128,9 +128,7 @@ class Renderer {
         if (page && !page.isClosed()) {
           await page.close();
         }
-      } catch (e) {
-        console.error(e);
-      }
+      } catch (e) {}
   }
 
   async close() {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -93,7 +93,8 @@ class Renderer {
         screenshotType,
         buffer,
       };
-    } finally {
+    }
+    finally {
       this.closePage(page);
     }
   }
@@ -101,6 +102,12 @@ class Renderer {
   async createPage(url, options = {}) {
     const { timeout, waitUntil, credentials, emulateMedia } = options;
     const page = await this.browser.newPage();
+
+    page.on('error', async (error) => {
+      console.error(error);
+      await this.closePage(page);
+    });
+
     if (emulateMedia) {
       await page.emulateMedia(emulateMedia);
     }
@@ -117,11 +124,13 @@ class Renderer {
   }
 
   async closePage(page) {
-    if (page) {
       try {
-        await page.close();
-      } catch (e) {}
-    }
+        if (page && !page.isClosed()) {
+          await page.close();
+        }
+      } catch (e) {
+        console.error(e);
+      }
   }
 
   async close() {


### PR DESCRIPTION
Hi!

It's me again 🙂 

I continued my researches regarding this issue (https://github.com/zenato/puppeteer-renderer/issues/34) and noticed that the memory usage of the docker container increased over time. Like 500mb per ~24 hours and I had to restart it several times to make it work again.

Further debugging the problem I forced page crashes by spamming 5 screenshot requests in a second.\
The page crashes but the emitted page error wasn't 'catched' and the code inside the `finally` block never executed.\
Which means that the pages weren't closed and more and more open pages on the browser object are created. Thus the `UnhandledPromiseRejectionWarning` in the logs.

To properly close the page on a crash, it was necessary to subscribe to the error event (https://github.com/puppeteer/puppeteer/blob/v5.5.0/docs/api.md#event-error) and close the page inside the callback.

The pull request also contains another small fix with having a Content-Type of `undefined` if no `screenshotType` parameter is passed.

Again thanks for the time you put into this!\
Looking forward to your feedback