### PR TITLE
Support for custom headers (setExtraHTTPHeaders)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,8 @@ app.use(async (req, res, next) => {
         if (!filename.toLowerCase().endsWith('.pdf')) {
           filename += '.pdf'
         }
-        const { contentDispositionType, ...pdfOptions } = options
-        const pdf = await renderer.pdf(url, pdfOptions)
+        const { contentDispositionType, headers, ...pdfOptions } = options
+        const pdf = await renderer.pdf(url, headers, pdfOptions)
         res
           .set({
             'Content-Type': 'application/pdf',

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,8 @@ app.use(async (req, res, next) => {
         if (!filename.toLowerCase().endsWith('.pdf')) {
           filename += '.pdf'
         }
-        const { contentDispositionType, headers, ...pdfOptions } = options
-        const pdf = await renderer.pdf(url, headers, pdfOptions)
+        const { contentDispositionType, ...pdfOptions } = options
+        const pdf = await renderer.pdf(url, pdfOptions)
         res
           .set({
             'Content-Type': 'application/pdf',

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -64,8 +64,8 @@ class Renderer {
   async html(url, options = {}) {
     let page = null
     try {
-      const { timeout, waitUntil, credentials } = options
-      page = await this.createPage(url, { timeout, waitUntil, credentials })
+      const { timeout, waitUntil, headers, credentials } = options
+      page = await this.createPage(url, headers, { timeout, waitUntil, credentials })
       const html = await page.content()
       return html
     } finally {
@@ -73,10 +73,10 @@ class Renderer {
     }
   }
 
-  async pdf(url, headers, options = {}) {
+  async pdf(url, options = {}) {
     let page = null
     try {
-      const { timeout, waitUntil, credentials, emulateMediaType, ...extraOptions } = options
+      const { timeout, waitUntil, credentials, emulateMediaType, headers, ...extraOptions } = options
       page = await this.createPage(url, headers, {
         timeout,
         waitUntil,
@@ -95,7 +95,7 @@ class Renderer {
   async screenshot(url, options = {}) {
     let page = null
     try {
-      const { timeout, waitUntil, credentials, ...restOptions } = options
+      const { timeout, waitUntil, credentials, headers, ...restOptions } = options
       const {
         width,
         height,
@@ -108,7 +108,7 @@ class Renderer {
         quality: validatedOptions.screenshotType === 'png' ? 0 : validatedOptions.quality,
       }
 
-      page = await this.createPage(url, { timeout, waitUntil, credentials })
+      page = await this.createPage(url, headers, { timeout, waitUntil, credentials })
       await page.setViewport({ width, height })
 
       if (animationTimeout > 0) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -73,18 +73,18 @@ class Renderer {
     }
   }
 
-  async pdf(url, options = {}) {
+  async pdf(url, headers, options = {}) {
     let page = null
     try {
       const { timeout, waitUntil, credentials, emulateMediaType, ...extraOptions } = options
-      page = await this.createPage(url, {
+      page = await this.createPage(url, headers, {
         timeout,
         waitUntil,
         credentials,
         emulateMediaType: emulateMediaType || 'print',
       })
-
       const pdfOptions = await pdfSchema.validate(extraOptions)
+      
       const buffer = await page.pdf(pdfOptions)
       return buffer
     } finally {
@@ -125,10 +125,16 @@ class Renderer {
     }
   }
 
-  async createPage(url, options = {}) {
+  async createPage(url, headers, options = {}) {
     const { timeout, waitUntil, credentials, emulateMediaType } = await pageSchema.validate(options)
     const page = await this.browser.newPage()
 
+    if (headers) {
+      await page.setExtraHTTPHeaders(
+        JSON.parse(headers)
+      )
+    }
+    
     await page.setCacheEnabled(false)
 
     page.on('error', async error => {


### PR DESCRIPTION
I added the support for custom headers following the puppeteer api **setExtraHTTPHeaders**. If you have a page that needs Authorization headers to be seen, now you can pass the custom headers in the request.

Another way of doing the same could have been to pass the custom headers in the request and then use that instead of having a parameter in the url.