### PR TITLE
Always use long versions of flags in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can run Chromium or docker.
 (service port: 3000)
 
 ### Start server using docker (If you can not run Chromium and installed docker)
-`docker run -d --name renderer -p 8080:3000 zenato/puppeteer-renderer`
+`docker run --detach --name renderer -publish 8080:3000 zenato/puppeteer-renderer`
 
 ### Test on your browser
 Input url `http://localhost:{port}/?url=https://www.google.com`


### PR DESCRIPTION
... or scripts. This makes reading them much easier if the reader isn't super familiar with the programs.