### PR TITLE
FIX：close page when page.goto has any exception to avoid orphan page …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ app.use(async (req, res, next) => {
   let { url, type, filename, ...options } = req.query
 
   if (!url) {
-    return res.status(400).send('Search with url parameter. For eaxample, ?url=http://yourdomain')
+    return res.status(400).send('Search with url parameter. For example, ?url=http://yourdomain')
   }
 
   if (!url.includes('://')) {
@@ -86,6 +86,7 @@ app.use((err, req, res, next) => {
 let puppeteerArgs = process.env.PUPPETEER_ARGS
 
 createRenderer({
+  //devtools:true,
   ignoreHTTPSErrors: !!process.env.IGNORE_HTTPS_ERRORS,
   // We want to support multiple args in a string, to support spaces we will use -- as the separator
   // and rebuild the array with valid values:

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -71,7 +71,7 @@ class Renderer {
       const html = await page.content()
       return html
     } finally {
-      this.closePage(page)
+      await this.closePage(page)
     }
   }
 
@@ -92,7 +92,7 @@ class Renderer {
       const buffer = await page.pdf(pdfOptions)
       return buffer
     } finally {
-      this.closePage(page)
+      await this.closePage(page)
     }
   }
 
@@ -121,7 +121,7 @@ class Renderer {
         buffer,
       }
     } finally {
-      this.closePage(page)
+      await this.closePage(page)
     }
   }
 
@@ -139,6 +139,7 @@ class Renderer {
     page.on('error', async error => {
       console.error(error)
       await this.closePage(page)
+      throw error
     })
 
     if (emulateMediaType) {
@@ -149,7 +150,11 @@ class Renderer {
       await page.authenticate(credentials)
     }
 
-    await page.goto(url, { timeout, waitUntil })
+    await page.goto(url, {timeout, waitUntil}).catch(async (e) => {
+      await this.closePage(page)
+      throw e
+    })
+
     return page
   }
 


### PR DESCRIPTION
…and memory leak

The root cause

`page.goto` will throw exception when timed out,
and the `page` var will never return

https://github.com/zenato/puppeteer-renderer/blob/f261521fe4cb7bc9d6bed5afcafc88e7024b584b/src/renderer.js#L152-L153

so the `finally` code block to close page will never be executed

https://github.com/zenato/puppeteer-renderer/blob/master/src/renderer.js#L124

which will cause an orphan page un-closed and memory leak

this can be  verified by turn on dev-tools