### PR TITLE
refactor: remove automation args at launching

### DIFF
--- a/packages/puppeteer-renderer/src/lib/renderer.ts
+++ b/packages/puppeteer-renderer/src/lib/renderer.ts
@@ -127,7 +127,7 @@ export default async function create(options: PuppeteerLaunchOptions = {}) {
   options.args.push('--no-sandbox')
   options.args.push('--disable-web-security')
 
-  const browser = await puppeteer.launch({ ...options, headless: 'new' })
+  const browser = await puppeteer.launch({ ...options, headless: 'new', ignoreDefaultArgs: ["--enable-automation"] })
 
   renderer = new Renderer(browser)
 


### PR DESCRIPTION
In most cases, `enable-automation` is not useful.