### PR TITLE
fix: update qs to v6.14.1 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.12.1",
+  "pnpm": {
+    "overrides": {
+      "qs": ">=6.14.1"
+    }
+  }
 }
 

--- a/packages/puppeteer-renderer/package.json
+++ b/packages/puppeteer-renderer/package.json
@@ -22,7 +22,7 @@
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
     "puppeteer": "^24.32.0",
-    "qs": "^6.11.1",
+    "qs": "^6.14.1",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs: '>=6.14.1'
+
 importers:
 
   .:
@@ -92,8 +95,8 @@ importers:
         specifier: ^24.32.0
         version: 24.32.0(typescript@5.9.3)
       qs:
-        specifier: ^6.11.1
-        version: 6.14.0
+        specifier: '>=6.14.1'
+        version: 6.14.1
       zod:
         specifier: ^4.1.13
         version: 4.1.13
@@ -1974,8 +1977,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -3201,7 +3204,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -3595,7 +3598,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.1
@@ -4205,7 +4208,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary
- Update direct dependency `qs` from `^6.11.1` to `^6.14.1`
- Add pnpm overrides to fix transitive dependency (`express` -> `qs`)
- Resolves [GHSA-6rw7-vpxm-498p](https://github.com/advisories/GHSA-6rw7-vpxm-498p) (DoS via memory exhaustion)

## Test plan
- [x] `pnpm audit` shows no vulnerabilities
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (3 tests)

Fixes PUP-1