### PR TITLE
chore: bump puppeteer-renderer-middleware to v1.0.2

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zenato/puppeteer-renderer"
   },
   "homepage": "https://github.com/zenato/puppeteer-renderer/tree/main/packages/middleware",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An Express middleware for SSR using puppeteer-renderer",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bump `puppeteer-renderer-middleware` version from 1.0.1 to 1.0.2

## Test plan
- Verify package.json version field is updated correctly