### PR TITLE
chore: ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 coverage
 node_modules
 
+.claude/settings.local.json
+


### PR DESCRIPTION
## Summary

Add `.claude/settings.local.json` to `.gitignore` so local Claude Code settings are not committed.