### PR TITLE
docs: add HTTP basic auth credentials usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These endpoints support both `GET` (query parameters) and `POST` (JSON body).
 
 The following options apply to `/html`, `/screenshot`, and `/pdf` endpoints.
 
-**Note:** For complex options like `headers`, `cookies`, and nested objects, use POST with JSON body. GET requests support dot notation for simple nested values (e.g., `viewport.width=1920`).
+**Note:** For complex options like `headers`, `cookies`, and nested objects, use POST with JSON body. GET requests support dot notation for simple nested values (e.g., `viewport.width=1920`, `credentials.username=user`).
 
 ### Common Options
 
@@ -152,6 +152,17 @@ curl -X POST http://localhost:3000/screenshot \
     "waitForSelector": "#main-content",
     "waitForSelectorTimeout": 10000
   }' -o screenshot.png
+
+# HTTP Basic Auth (credentials)
+curl -X POST http://localhost:3000/screenshot \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "credentials": { "username": "user", "password": "pass" }
+  }' -o screenshot.png
+
+# Same via GET using dot notation
+curl "http://localhost:3000/screenshot?url=https://example.com&credentials.username=user&credentials.password=pass" -o screenshot.png
 ```
 
 ## Error Response


### PR DESCRIPTION
## Summary

Adds concrete usage examples for HTTP basic auth `credentials` to the README. The `credentials.username` / `credentials.password` fields were listed in the options table but had no example showing how to actually pass them, which caused confusion (#120).

## Changes

- Add a POST (nested JSON object) example and a GET (dot notation) example for `credentials` in the Usage Examples section.
- Mention `credentials.username` in the dot-notation note.

No code changes — the feature already works via Puppeteer's `page.authenticate()`.

Closes #120

https://claude.ai/code/session_01E2n8CipEUWmX8zRPsw3bUT